### PR TITLE
Added auth0 mock to fix tests

### DIFF
--- a/__mocks__/@auth0/nextjs-auth0.js
+++ b/__mocks__/@auth0/nextjs-auth0.js
@@ -1,0 +1,1 @@
+export const withApiAuthRequired = jest.fn()


### PR DESCRIPTION
I did manage to break the tests after that last PR got merged to main. It didn't have a mock for `auth0` and was trying to call that service directly without a valid API key. 